### PR TITLE
Forced allDay to be false for closings. Fix #37

### DIFF
--- a/application/controllers/Appointment.php
+++ b/application/controllers/Appointment.php
@@ -141,7 +141,7 @@ class Appointment extends CI_Controller
 
 			$event = array(
 				'title' 	=> $title,
-				'allDay'	=> $from->diff($to)->format('%a') > 1,
+				'allDay'	=> false,
 				'start' 	=> $from->format(DateTime::ISO8601),
 				'end'		=> $to->format(DateTime::ISO8601),
 				'tooltip'	=> $closing->comment,


### PR DESCRIPTION
It breaks the calendar for multi-day closing. Which is ironic, as it's only true in that case.